### PR TITLE
Fix broken tokenizer imports

### DIFF
--- a/case_studies/contextual_nearest_neighbors/scripts/gen_berts.py
+++ b/case_studies/contextual_nearest_neighbors/scripts/gen_berts.py
@@ -1,6 +1,6 @@
 import argparse, sys
-from cltk.tokenize.word import WordTokenizer
-from cltk.tokenize.latin.sentence import SentenceTokenizer
+from cltk.tokenizers.lat.lat import LatinWordTokenizer as WordTokenizer
+from cltk.tokenizers.lat.lat import LatinPunktSentenceTokenizer as SentenceTokenizer
 from tensor2tensor.data_generators import text_encoder
 import numpy as np
 import torch
@@ -249,7 +249,7 @@ class LatinTokenizer():
 def convert_to_toks(sents):
 
 	sent_tokenizer = SentenceTokenizer()
-	word_tokenizer = WordTokenizer('latin')
+	word_tokenizer = WordTokenizer()
 
 	all_sents=[]
 

--- a/case_studies/contextual_nearest_neighbors/scripts/gen_berts_to_file.py
+++ b/case_studies/contextual_nearest_neighbors/scripts/gen_berts_to_file.py
@@ -1,6 +1,6 @@
 import argparse, sys
-from cltk.tokenize.word import WordTokenizer
-from cltk.tokenize.latin.sentence import SentenceTokenizer
+from cltk.tokenizers.lat.lat import LatinWordTokenizer as WordTokenizer
+from cltk.tokenizers.lat.lat import LatinPunktSentenceTokenizer as SentenceTokenizer
 from tensor2tensor.data_generators import text_encoder
 import numpy as np
 import torch
@@ -64,7 +64,7 @@ class LatinTokenizer():
 
 def read_file(filename):
 	sent_tokenizer = SentenceTokenizer()
-	word_tokenizer = WordTokenizer('latin')
+	word_tokenizer = WordTokenizer()
 
 	all_sents=[]
 	with open(filename, encoding="utf-8") as file:

--- a/case_studies/infilling/scripts/check_dupes_emendations.py
+++ b/case_studies/infilling/scripts/check_dupes_emendations.py
@@ -1,8 +1,7 @@
 import sys, re
-from cltk.tokenize.word import WordTokenizer
-from cltk.tokenize.latin.sentence import SentenceTokenizer
+from cltk.tokenizers.lat.lat import LatinWordTokenizer as WordTokenizer
 
-word_tokenizer = WordTokenizer('latin')
+word_tokenizer = WordTokenizer()
 
 def filt(text):
 	text=re.sub("<", "", text)

--- a/case_studies/infilling/scripts/predict_word.py
+++ b/case_studies/infilling/scripts/predict_word.py
@@ -5,11 +5,9 @@ from transformers import BertModel, BertForMaskedLM, BertPreTrainedModel
 from tensor2tensor.data_generators import text_encoder
 import torch
 import numpy as np
-from cltk.tokenize.word import WordTokenizer
-from cltk.tokenize.latin.sentence import SentenceTokenizer
+from cltk.tokenizers.lat.lat import LatinWordTokenizer as WordTokenizer
 from torch import nn
 import random
-from random import randrange
 
 random.seed(1)
 
@@ -20,7 +18,7 @@ class LatinTokenizer():
 		self.vocab={}
 		self.reverseVocab={}
 		self.encoder=encoder
-		self.word_tokenizer = WordTokenizer('latin')
+		self.word_tokenizer = WordTokenizer()
 
 		self.vocab["[PAD]"]=0
 		self.vocab["[UNK]"]=1
@@ -241,5 +239,3 @@ if __name__ == "__main__":
 	model.to(device)
 
 	proc_file(dataFile, wp_tokenizer, model)
-
-

--- a/case_studies/wsd/scripts/create_wsd_data.py
+++ b/case_studies/wsd/scripts/create_wsd_data.py
@@ -1,8 +1,8 @@
 import sys, re
-from cltk.tokenize.word import WordTokenizer
+from cltk.tokenizers.lat.lat import LatinWordTokenizer as WordTokenizer
 from unidecode import unidecode
 
-word_tokenizer = WordTokenizer('latin')
+word_tokenizer = WordTokenizer()
 
 def read_lemmas(filename):
 	lemmadict={}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pygame==2.0.0.dev6
 beautifulsoup4==4.9.1
-cltk==0.1.121
+cltk==1.0.15
 future==0.18.2
 numpy==1.18.5
 tensor2tensor==1.15.7

--- a/scripts/gen_berts.py
+++ b/scripts/gen_berts.py
@@ -1,6 +1,6 @@
 import argparse, sys
-from cltk.tokenize.word import WordTokenizer
-from cltk.tokenize.latin.sentence import SentenceTokenizer
+from cltk.tokenizers.lat.lat import LatinWordTokenizer as WordTokenizer
+from cltk.tokenizers.lat.lat import LatinPunktSentenceTokenizer as SentenceTokenizer
 from tensor2tensor.data_generators import text_encoder
 import numpy as np
 import torch
@@ -235,7 +235,7 @@ class LatinTokenizer():
 def convert_to_toks(sents):
 
 	sent_tokenizer = SentenceTokenizer()
-	word_tokenizer = WordTokenizer('latin')
+	word_tokenizer = WordTokenizer()
 
 	all_sents=[]
 


### PR DESCRIPTION
* Fixed broken tokenizer imports to match an updated CLTK release.
* Updated the `requirements.txt` with a working CLTK version.

Fixes issue: [https://github.com/dbamman/latin-bert/issues/3]

All other libraries installed as listed in the requirements file.
Verified with an install of PyTorch 1.10.0 and execution of the scripts:

`python3 scripts/gen_berts.py --bertPath models/latin_bert/ --tokenizerPath models/subword_tokenizer_latin/latin.subword.encoder`

`python3 scripts/predict_word.py --bertPath ../../models/latin_bert/ --tokenizerPath ../../models/subword_tokenizer_latin/latin.subword.encoder -d data/emendation_filtered.txt > logs/infilling.log 2>&1`

