### PR TITLE
Fix gen_berts.py not running with newer transformers versions

### DIFF
--- a/scripts/gen_berts.py
+++ b/scripts/gen_berts.py
@@ -272,8 +272,12 @@ class BertLatin(nn.Module):
 		input_ids = input_ids.to(device)
 		attention_mask = attention_mask.to(device)
 		transforms = transforms.to(device)
-		sequence_outputs, pooled_outputs = self.bert.forward(input_ids, token_type_ids=None, attention_mask=attention_mask)
-
+		
+		outputs = self.bert.forward(input_ids, token_type_ids=None, attention_mask=attention_mask)
+		# 'outputs' from BERT is a transformers.modeling_outputs.BaseModelOutputWithCrossAttentions object
+		sequence_outputs = outputs["last_hidden_state"]
+		pooled_outputs = outputs["pooler_output"]
+		
 		all_layers=sequence_outputs
 		out=torch.matmul(transforms,all_layers)
 		return out


### PR DESCRIPTION
In recent versions of `transformers`, BERT Models no longer output raw vectors, instead they output `ModelOutput` [objects](https://huggingface.co/docs/transformers/main_classes/output), which are dictionary-like.

 This PR fixes a problem where the output of the model was being cast to a tuple. Casting a `ModelOutput` object to a tuple returns a tuple of its string **keys**, not its tensor **values**.  This raised an error, as `torch.matmul` was receiving a string, instead of a tensor.

The following line casts the output to a tuple :

`sequence_outputs, pooled_outputs = self.bert.forward(...)`

This line has been changed in this PR to explicitly obtain the tensors.
