### PR TITLE
Fix unpack in latin_sequence_labeling.py

### DIFF
--- a/case_studies/pos_tagging/scripts/latin_sequence_labeling.py
+++ b/case_studies/pos_tagging/scripts/latin_sequence_labeling.py
@@ -111,7 +111,7 @@ class BertForSequenceLabeling(nn.Module):
 		if labels is not None:
 			labels = labels.to(device)
 
-		sequence_outputs, pooled_outputs = self.bert(input_ids, token_type_ids=None, attention_mask=attention_mask)
+		sequence_outputs, pooled_outputs = self.bert(input_ids, token_type_ids=None, attention_mask=attention_mask).values()
 		all_layers=sequence_outputs
 		out=torch.matmul(transforms,all_layers)
 


### PR DESCRIPTION
This might be because of changed behaviour in a new python version.  Unpacking the bert output into sequence_outputs and pooled_outputs gave those values the name of the keys, and not the actual tensors. This PR fixes it by getting the values